### PR TITLE
Do not display 2D, save to png directly

### DIFF
--- a/stable_fluids_fft.jl
+++ b/stable_fluids_fft.jl
@@ -119,6 +119,8 @@ KINEMATIC_VISCOSITY = 0.0001
 TIME_STEP_LENGTH = 0.01
 N_TIME_STEPS = 300
 
+PLOT_INTERACTIVELY = true
+
 function backtrace!(
     backtraced_positions,
     original_positions,
@@ -249,8 +251,12 @@ function main()
         d_u__d_y = diff(velocity_x, dims=2)[2:end, :]
         d_v__d_x = diff(velocity_y, dims=1)[:, 2:end]
         curl = d_u__d_y - d_v__d_x
-        plotref = heatmap(x_interval, y_interval, curl', c=:diverging_bkr_55_10_c35_n256, aspect_ratio=:equal, size=(680, 650))
-        savefig(plotref, "collision_2d_$iter.png")
+        if PLOT_INTERACTIVELY
+            display(heatmap(x_interval, y_interval, curl', c=:diverging_bkr_55_10_c35_n256, aspect_ratio=:equal, size=(680, 650)))
+        else
+            plotref = heatmap(x_interval, y_interval, curl', c=:diverging_bkr_55_10_c35_n256, aspect_ratio=:equal, size=(680, 650))
+            savefig(plotref, "collision_2d_$iter.png")
+        end
     end
 end
 

--- a/stable_fluids_fft.jl
+++ b/stable_fluids_fft.jl
@@ -249,8 +249,8 @@ function main()
         d_u__d_y = diff(velocity_x, dims=2)[2:end, :]
         d_v__d_x = diff(velocity_y, dims=1)[:, 2:end]
         curl = d_u__d_y - d_v__d_x
-        display(heatmap(x_interval, y_interval, curl', c=:diverging_bkr_55_10_c35_n256, aspect_ratio=:equal, size=(680, 650)))
-        savefig("collision_2d_$iter.png")
+        plotref = heatmap(x_interval, y_interval, curl', c=:diverging_bkr_55_10_c35_n256, aspect_ratio=:equal, size=(680, 650))
+        savefig(plotref, "collision_2d_$iter.png")
     end
 end
 


### PR DESCRIPTION
This speeds up the 2D simulation for me by not displaying the plot, but saving it directly. The 2D simulation takes about 38 seconds with this change.