### PR TITLE
Add interactive 2D movie player and loader

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,8 +5,12 @@ version = "0.1.0"
 
 [deps]
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+ImageIO = "82e4d734-157c-48bb-816b-45c225c6df19"
+ImageView = "86fae568-95e7-573e-a6b2-d8a6b900c9ef"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+PNGFiles = "f57f5aa1-a3ce-4bc8-8ab9-96f992907883"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"

--- a/src/StableFluids.jl
+++ b/src/StableFluids.jl
@@ -14,4 +14,7 @@ module StableFluids
 
     run_2D() = TwoDims.main()
     run_3D() = ThreeDims.main()
+
+    load_2D() = TwoDims.load_movie()
+    play_2D(args...) = TwoDims.replay_movie(args...)
 end

--- a/src/TwoDims.jl
+++ b/src/TwoDims.jl
@@ -3,4 +3,24 @@ module TwoDims
     include("../stable_fluids_fft.jl")
 
     precompile(main, ())
+
+    using ImageView
+    using FileIO
+    using PNGFiles
+    
+    function load_movie(n_frames = N_TIME_STEPS)
+        first_frame = load("collision_2d_1.png")
+        movie = Array{eltype(first_frame), 3}(undef, (size(first_frame)..., n_frames))
+        movie[:,:,begin] = first_frame
+        @info "Movie" size(movie)
+        @showprogress "Loading pngs..." for (i,s) = enumerate(eachslice(movie; dims=3))
+            s .= load("collision_2d_$i.png")
+        end
+        movie
+    end
+    function replay_movie(movie = load_movie())
+        h = imshow(movie)
+        p = h["gui"]["players"][1]
+        push!(p.widget.direction, +1)
+    end
 end


### PR DESCRIPTION
This adds an interactive movie player for the 2D version. It loads the pngs from disk and puts them into a player via ImageView.jl:
![image](https://user-images.githubusercontent.com/8062771/151680329-f09446be-77c3-46e7-9cdf-e4960c98a3c2.png)
